### PR TITLE
Improved CC Player Parsing

### DIFF
--- a/ccs.js
+++ b/ccs.js
@@ -303,7 +303,7 @@ module.exports = function() {
 		}
 		let ccOwner = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member").filter(el => el.allow == 66560).map(el => el.id);
 		if(mode || isGameMaster(member) || ccOwner.includes(member.id)) {
-			players = getUserList(channel, args, 1, member);
+			players = parseUserList(channel, args, 1, member);
 			let playerList = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member" && el.allow > 0).map(el => el.id);
 			if(players && players.length > 0) {
 				players = players.filter(el => !playerList.includes(el));
@@ -332,7 +332,7 @@ module.exports = function() {
 		}
 		let ccOwner = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member").filter(el => el.allow == 66560).map(el => el.id);
 		if(mode || isGameMaster(member) || ccOwner.includes(member.id)) {
-			players = getUserList(channel, args, 1, member);
+			players = parseUserList(channel, args, 1, member);
 			let playerList = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member" && el.allow > 0).map(el => el.id);
 			if(players) players = players.filter(el => playerList.includes(el));
 			if(players && players.length > 0) {
@@ -415,7 +415,7 @@ module.exports = function() {
 		let ccOwner = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member").filter(el => el.allow == 66560).map(el => el.id);
 		if(mode || isGameMaster(member) || ccOwner.includes(member.id)) {
 			// Get members
-			players = getUserList(channel, args, 1, member);
+			players = parseUserList(channel, args, 1, member);
 			let playerList = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member" && el.allow > 0).map(el => el.id);
 			if(players) players = players.filter(el => playerList.includes(el));
 			if(players && players.length > 0) {
@@ -450,7 +450,7 @@ module.exports = function() {
 		let ccOwner = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member").filter(el => el.allow == 66560).map(el => el.id);
 		if(mode || isGameMaster(member) || ccOwner.includes(member.id)) {
 			// Get members
-			players = getUserList(channel, args, 1, member);
+			players = parseUserList(channel, args, 1, member);
 			let playerList = channel.permissionOverwrites.cache.toJSON().filter(el => el.type === "member" && el.allow > 0).map(el => el.id);
 			if(players) players = players.filter(el => playerList.includes(el));
 			if(players && players.length > 0) {
@@ -567,7 +567,7 @@ module.exports = function() {
 			});
 		}
 		args[1] = args[1].replace(/🔒/,"lock");
-		players = getUserList(channel, args, 2, member);
+		players = parseUserList(channel, args, 2, member);
         players = players.filter(el => el != member.id);
 		if(isParticipant(member) || players.length > 0) {
 			sqlGetStat(9, result => {

--- a/players.js
+++ b/players.js
@@ -1171,4 +1171,13 @@ module.exports = function() {
 		});
 	}
 	
+	
+	this.getIDs = function() {
+		sql("SELECT id FROM players", result => {
+				playerIDs = result.map(el => el.id);
+		}, () => {
+			log("Players > ❗❗❗ Unable to cache player ids!");
+		});
+	}
+	
 }

--- a/players.js
+++ b/players.js
@@ -1192,36 +1192,6 @@ module.exports = function() {
 		});
 	}
 	
-	this.strDst = function (str1 = "", str2 = "") {
-	    // create empty matrix, with row 1 and column 1 filled with incrementing numbers
-	    var len1 = str1.length, len2 = str2.length;
-	    var track = Array(len2 + 1).fill().map((_, ind1) => 
-		Array(len1 + 1).fill().map((_, ind2) =>
-		    !ind1 ? ind2 : (!ind2 ? ind1 : null)
-		)
-	    );
-	    // determine levenshtein distance
-	    for(let j = 1; j <= len2; j++) {
-		for(let i = 1; i <= len1; i++) {
-		    const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
-		    track[j][i] = Math.min(
-			track[j][i - 1] + 1, // deletion
-			track[j - 1][i] + 1, // insertion
-			track[j - 1][i - 1] + indicator // substitution
-		    );
-		}
-	    }
-	    return track[len2][len1];
-	};
-
-	// finds the best match for arg1 in the list arg2
-	this.findBestMatch = function(name = "", players = []) {
-	    let w = players.map(p => strDst(p, name));
-	    // get index of closest match (lowest weight)
-	    let best = w.reduce((iMax, x, i, arr) => x < arr[iMax] ? i : iMax, 0);
-	    return {value: w[best], index: best, name: players[best]};
-	}
-
 	this.parseList = function(inputList, allPlayers) {
 	    let playerList = [];
 	    // filter out ids, emojis, unicode

--- a/players.js
+++ b/players.js
@@ -1064,8 +1064,8 @@ module.exports = function() {
 	}
 	
 	this.fixUserList = function(list) {
-		let allPlayerNames = playerIDs.map(el => client.users.cache.find(user => user.id === el)?.username).filter(el => el);
-		let parsed = parseList(list, allPlayerNames);
+		let allPlayerNames = playerIDs.map(el => client.users.cache.find(user => user.id === el)?.username).filter(el => el).map(el => el.toLowerCase());
+		let parsed = parseList(list.map(el => el.toLowerCase()), allPlayerNames);
 		return [...parsed.invalid, ...parsed.found];
 	}
 	

--- a/roles.js
+++ b/roles.js
@@ -1225,6 +1225,22 @@ module.exports = function() {
 	}
     
     this.cmdInfoEither = function(channel, args, pin, noErr, simp = false) {
+		// fix role name if necessary
+		let roleName = args.join(" ").replace(/[^a-zA-Z0-9'\-]+/g,"");
+		if(!verifyRoleVisible(roleName)) { // not a valid role
+			// get all roles and aliases, to get an array of all possible role names
+			let allRoleNames = [...cachedRoles, ...cachedAlias.map(el => el.alias)];
+			let bestMatch = findBestMatch(roleName, allRoleNames); // find closest match
+			// check if match is close enough
+			if(bestMatch.value <= ~~(roleName.length/2)) { // auto alias if so, but send warning 
+				args = [parseRole(bestMatch.name)];
+				channel.send("❗ Could not find role `" + roleName + "`. Did you mean `" args[0] + "`?");
+			} else { // early fail if otherwise
+				channel.send("❗ Could not find role `" + roleName + "`.");
+			}
+		}
+		
+		// run info command
         if(stats.fancy_mode) {
             cmdInfoFancy(channel, args, pin, noErr, simp);
         } else {

--- a/utility.js
+++ b/utility.js
@@ -478,11 +478,11 @@ module.exports = function() {
 	};
 
 	// finds the best match for arg1 in the list arg2
-	this.findBestMatch = function(name = "", players = []) {
-	    let w = players.map(p => strDst(p, name));
+	this.findBestMatch = function(name = "", list = []) {
+	    let w = list.map(p => strDst(p, name));
 	    // get index of closest match (lowest weight)
 	    let best = w.reduce((iMax, x, i, arr) => x < arr[iMax] ? i : iMax, 0);
-	    return {value: w[best], index: best, name: players[best]};
+	    return {value: w[best], index: best, name: list[best]};
 	}
 
 	

--- a/utility.js
+++ b/utility.js
@@ -452,4 +452,38 @@ module.exports = function() {
         return response.ok;
     }
 	
+	// returns a value for how many edits (additions, removals, replacements) are necessary to turn one string into another
+	// this means it basically gives a score on how close two strings are, with closer values being better
+	// known as "levenshtein distance"
+	this.strDst = function (str1 = "", str2 = "") {
+	    // create empty matrix, with row 1 and column 1 filled with incrementing numbers
+	    var len1 = str1.length, len2 = str2.length;
+	    var track = Array(len2 + 1).fill().map((_, ind1) => 
+		Array(len1 + 1).fill().map((_, ind2) =>
+		    !ind1 ? ind2 : (!ind2 ? ind1 : null)
+		)
+	    );
+	    // determine levenshtein distance
+	    for(let j = 1; j <= len2; j++) {
+		for(let i = 1; i <= len1; i++) {
+		    const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+		    track[j][i] = Math.min(
+			track[j][i - 1] + 1, // deletion
+			track[j - 1][i] + 1, // insertion
+			track[j - 1][i - 1] + indicator // substitution
+		    );
+		}
+	    }
+	    return track[len2][len1];
+	};
+
+	// finds the best match for arg1 in the list arg2
+	this.findBestMatch = function(name = "", players = []) {
+	    let w = players.map(p => strDst(p, name));
+	    // get index of closest match (lowest weight)
+	    let best = w.reduce((iMax, x, i, arr) => x < arr[iMax] ? i : iMax, 0);
+	    return {value: w[best], index: best, name: players[best]};
+	}
+
+	
 }

--- a/werewolves.js
+++ b/werewolves.js
@@ -21,6 +21,7 @@ client.on("ready", () => {
 	sqlSetup();
 	getStats();
 	setTimeout(function() {
+		getIDs();
 		cacheRoleInfo();
 		getVotes();
 		getCCs();


### PR DESCRIPTION
This improves the parsing of player lists in cc commands, allowing typos and incorrect quoting.

Examples:

Given these participants:
- Ts
- Marten
- shapechange
- qwertzuio
- Sharl Eclair
- ab c

`$cc create CC ts mrtn shalr elciar` => Ts, Marten, Sharl Eclair
`$cc create CC "ab c" "shalkr eclair" shape change` => ab c, Sharl Eclair, shapechange