### PR TITLE
Disguises: Dash to Space

### DIFF
--- a/whispers.js
+++ b/whispers.js
@@ -186,7 +186,7 @@ module.exports = function() {
 							if(destination.channel_id != message.channel.id) { 	
 								// Create webhook
                                 let pdis = idToDisguise(message.author.id);
-                                let disguiseName = source.name;
+                                let disguiseName = source.name.replace(/\-/," ");
                                 let disguiseAvatar = client.user.displayAvatarURL();
                                 
                                 // role icon


### PR DESCRIPTION
replace dashes with spaces in disguises.
This is necessary because channel setup commands are quoted meaning the quoted channel commands containing the disguise setup commands may not contain quotes themselves as these would clash with the quotes of the outer setup commands, as a consequence of this the disguise setup needs to happen without using any quotes which means that role names with spaces in their name cannot be used as a disguise. As a workaround for that I have been using hyphens to connect the two segments of the name. To return this into the proper name format, replace hyphens with spaces.